### PR TITLE
Fixed tests and light mode style

### DIFF
--- a/dev_environment/environment.yml
+++ b/dev_environment/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - jupyterlab=4.2.4
   - jupyterlab-spellchecker=0.8.4
   - libtiff=4.5.1
-  - lintquarto=0.7.0
+  - lintquarto=0.8.0
   - matplotlib=3.9.2
   - nbqa
   - numpy=1.26.2
@@ -23,7 +23,7 @@ dependencies:
   - pytest=8.3.2
   - pytest-html=4.1.1
   - quartodoc=0.9.1
-  - simpy=4.0.2
+  - simpy=4.1.1
   - sim-tools=0.9.0
   - streamlit=1.52.2
   - tox=4.25.0

--- a/dev_environment/requirements.txt
+++ b/dev_environment/requirements.txt
@@ -7,7 +7,7 @@ ipywidgets==8.1.5
 ipycytoscape==1.3.3
 jupyterlab==4.2.4
 jupyterlab-spellchecker==0.8.4
-lintquarto==0.7.0
+lintquarto==0.8.0
 matplotlib==3.9.2
 mesa==2.3.0
 nbqa
@@ -20,7 +20,7 @@ pydantic==2.10.4
 pytest==8.3.2
 pytest-html==4.1.1
 quartodoc==0.9.1
-simpy==4.0.2
+simpy==4.1.1
 sim-tools==0.9.0
 st-cytoscape==0.0.5
 streamlit==1.52.2

--- a/vidigi_docs/styles.css
+++ b/vidigi_docs/styles.css
@@ -43,7 +43,6 @@
   --bs-card-cap-color: ;
   --bs-card-height: ;
   --bs-card-color: ;
-  --bs-card-bg: #2d2d2d;
   --bs-card-img-overlay-padding: 1rem;
   --bs-card-group-margin: 0.75rem;
   position: relative;
@@ -61,6 +60,16 @@
   border: var(--bs-card-border-width) solid var(--bs-card-border-color);
   border-radius: var(--bs-card-border-radius);
   max-width: min(99%, 100vw - 10px);
+}
+
+/* Card background colour differs between light and dark mode */
+body.quarto-light .custom-grid-card {
+  --bs-card-bg: #f6fff0;
+  background-color: var(--bs-card-bg);
+}
+body.quarto-dark .custom-grid-card {
+  --bs-card-bg: #2d2d2d;
+  background-color: var(--bs-card-bg);
 }
 
 .main-card-content {
@@ -200,3 +209,9 @@
 }
 
 .bg-green { background-color: #216630; }
+
+body.quarto-light .footer,
+body.quarto-light .nav-footer {
+  background-color: #216630;
+  color: #ffffff;
+}


### PR DESCRIPTION
Hello Sammi! @Bergam0t 

Just a little pull request for you, as I was procrastinating other work and decided to do a few bits and bobs :grin: 

## Fixed

* Tests action was failing due to a `pkg_resources` error - resolved by upgrading `simpy`.
* Style on light mode - addressed two issues: (1) `.custom-grid-card` background colour was dark, so on light mode, could not read the black text on the black background (2) the HSMA and NIHR logos are white, so on light mode, not visible - fixed by making the footer dark in light mode.

## Changed

* Upgraded `lintquarto`.
